### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -27,15 +27,19 @@ jobs:
     steps:
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$DISPATCH_VERSION"
           else
             # Get the tag from the workflow run
             # The release workflow runs on tag push, so we extract from head_branch
-            VERSION="${{ github.event.workflow_run.head_branch }}"
+            VERSION="$HEAD_BRANCH"
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Release version: $VERSION"
 
       - name: Get release tarball URL


### PR DESCRIPTION
Potential fix for [https://github.com/SyntheticAutonomicMind/CLIO/security/code-scanning/1](https://github.com/SyntheticAutonomicMind/CLIO/security/code-scanning/1)

To fix the problem, we should avoid using the GitHub expression `${{ github.event.workflow_run.head_branch }}` directly inside the shell script in `run:`. Instead, we should assign any such value to an environment variable using workflow syntax, then reference it via native shell variable expansion (`$VAR`). This prevents GitHub expression syntax from being interpreted in the shell and keeps data and code clearly separated.

Concretely, in the `Extract version` step, we will define an `env:` section that provides two environment variables: one for the dispatch input (`DISPATCH_VERSION`) and one for the workflow run branch (`HEAD_BRANCH`). Inside the `run:` script, we will then use `$DISPATCH_VERSION` and `$HEAD_BRANCH` to set `VERSION`, instead of embedding `${{ ... }}` directly. The logic of the step (choosing between manual dispatch version and workflow-run branch) remains unchanged.

The change is localized to the `Extract version` step in `.github/workflows/update-homebrew.yml` (lines 28–39). No new imports or external dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
