### PR TITLE
fix: auto-reap zombie child processes

### DIFF
--- a/lib/CLIO/Coordination/SubAgent.pm
+++ b/lib/CLIO/Coordination/SubAgent.pm
@@ -9,6 +9,12 @@ use utf8;
 use CLIO::Coordination::Broker;
 use CLIO::Coordination::Client;
 use CLIO::Core::Logger qw(log_debug log_warning);
+use POSIX qw(WNOHANG);
+
+# Auto-reap zombie children to prevent process table exhaustion.
+# This ensures forked sub-agents are properly reaped by the parent.
+$SIG{CHLD} = sub { 1 while waitpid(-1, WNOHANG) > 0 };
+
 use POSIX qw(setsid);
 use Carp qw(croak);
 


### PR DESCRIPTION
## Summary

Fixes zombie process accumulation that causes flatpak failures after extended use.

## Problem

When using 
[1m[96mCLIO [36m- Command Line Intelligence Orchestrator[0m
[2m[37mSession ID: [97mab2a24ed-a6f7-4f9a-b1e9-423352879866[0m
[2m[37mYou are connected to [97mMiniMax-M2.7@MiniMax Token Plan[0m
[2m[37mType "[97m/help[2m[37m" for a list of commands.[0m

[92m: [0m

[2m∙[0m[36m SYSTEM [0m[2m→ [0m[91mSaving session[0m
[2m∙[0m[36m SYSTEM [0m[2m→ [0m[91mGoodbye![0m, sub-agents are forked via SubAgent::spawn_agent() but never reaped. Each completed agent becomes a zombie until CLIO exits. Over time, this exhausts the process table and breaks flatpak sandboxing (bubblewrap/bpf failures).

## Solution

Add SIGCHLD handler to automatically reap dead children:

```perl
use POSIX qw(WNOHANG);
$SIG{CHLD} = sub { 1 while waitpid(-1, WNOHANG) > 0 };
```

## Testing

Monitor dlafren+  437097  0.0  0.0 232028  3820 pts/4    S+   14:44   0:00 bash -c cd /tmp/CLIO && gh pr create --repo SyntheticAutonomicMind/CLIO --head dtg01100:fix/zombie-process-reaping --title "fix: auto-reap zombie child processes" --body "## Summary  Fixes zombie process accumulation that causes flatpak failures after extended use.  ## Problem  When using `clio --resume`, sub-agents are forked via SubAgent::spawn_agent() but never reaped. Each completed agent becomes a zombie until CLIO exits. Over time, this exhausts the process table and breaks flatpak sandboxing (bubblewrap/bpf failures).  ## Solution  Add SIGCHLD handler to automatically reap dead children:  \`\`\`perl use POSIX qw(WNOHANG); \$SIG{CHLD} = sub { 1 while waitpid(-1, WNOHANG) > 0 }; \`\`\`  ## Testing  Monitor `ps aux | grep defunct` before and after patch during normal `clio --resume` usage. Zombies should no longer accumulate. " 2>&1
dlafren+  437104  0.0  0.0 232028  1828 pts/4    S+   14:44   0:00 bash -c cd /tmp/CLIO && gh pr create --repo SyntheticAutonomicMind/CLIO --head dtg01100:fix/zombie-process-reaping --title "fix: auto-reap zombie child processes" --body "## Summary  Fixes zombie process accumulation that causes flatpak failures after extended use.  ## Problem  When using `clio --resume`, sub-agents are forked via SubAgent::spawn_agent() but never reaped. Each completed agent becomes a zombie until CLIO exits. Over time, this exhausts the process table and breaks flatpak sandboxing (bubblewrap/bpf failures).  ## Solution  Add SIGCHLD handler to automatically reap dead children:  \`\`\`perl use POSIX qw(WNOHANG); \$SIG{CHLD} = sub { 1 while waitpid(-1, WNOHANG) > 0 }; \`\`\`  ## Testing  Monitor `ps aux | grep defunct` before and after patch during normal `clio --resume` usage. Zombies should no longer accumulate. " 2>&1
dlafren+  437106  0.0  0.0 231272  2400 pts/4    S+   14:44   0:00 grep defunct before and after patch during normal 
[1m[96mCLIO [36m- Command Line Intelligence Orchestrator[0m
[2m[37mSession ID: [97mab2a24ed-a6f7-4f9a-b1e9-423352879866[0m
[2m[37mYou are connected to [97mMiniMax-M2.7@MiniMax Token Plan[0m
[2m[37mType "[97m/help[2m[37m" for a list of commands.[0m

[92m: [0m

[2m∙[0m[36m SYSTEM [0m[2m→ [0m[91mSaving session[0m
[2m∙[0m[36m SYSTEM [0m[2m→ [0m[91mGoodbye![0m usage. Zombies should no longer accumulate.
